### PR TITLE
fix: get nb baseUrl error

### DIFF
--- a/packages/labextension/src/widget.ts
+++ b/packages/labextension/src/widget.ts
@@ -102,7 +102,7 @@ class NbdimeWidget extends Panel {
     }
 
     requestApiJson(
-      ServerConnection.defaultSettings.baseUrl,
+      ServerConnection.makeSettings().baseUrl,
       'nbdime/api/diff',
       args,
       this.onData.bind(this),


### PR DESCRIPTION
When I click the git button on the statusbar, it has something wrong:
**Cannot read property 'baseUrl' of undefined**

defaultSettings doesn't declare in ServerConnection, so I replaced defaultSettings with makeSettings()

